### PR TITLE
Create RoutesVersionSix.jsx

### DIFF
--- a/src/components/RoutesVersionSix.jsx
+++ b/src/components/RoutesVersionSix.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import {Navigate, useRoutes} from 'react-router-dom';
+import { Results } from './Results';
+
+
+export const Routes = () => {
+  const elements  = useRoutes([
+    {path: "/", element: <Navigate to="/search"/>},
+    { path: "/search", element: <Results /> },
+    { path: "/videos", element: <Results /> },
+    { path: "/images", element: <Results /> },
+    { path: "/news", element: <Results /> },
+  ]);
+
+  return elements;
+}


### PR DESCRIPTION
Update for React Router v6
React Router v6 no longer allows an array of paths to be passed as a Route property. Instead you can make use of the useRoutes React hook to achieve the same behaviour.
Documentation: https://reactrouter.com/docs/en/v6/api#useroutes