### PR TITLE
Update Loading.jsx

### DIFF
--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Loader from 'react-loader-spinner';
+import {Puff} from 'react-loader-spinner';
 
 export const Loading = () => (
   <div className="flex justify-center items-center ">
-    <Loader type="Puff" color="#00BFFF" height={550} width={80} />
+    <Puff color="#00BFFF" height={550} width={80} />
   </div>
 );


### PR DESCRIPTION
export 'default' (imported as 'Loader') was not found in 'react-loader-spinner' (possible exports: [...], Puff)